### PR TITLE
Fix htaccess syntax, that leads to 500-error on apache server

### DIFF
--- a/lib/Phile/Bootstrap.php
+++ b/lib/Phile/Bootstrap.php
@@ -149,7 +149,7 @@ class Bootstrap {
 			if ($dir['protected']) {
 				$file = "$path.htaccess";
 				if (!file_exists($file)) {
-					$content = "order deny, allow\ndeny from all\nallow from 127.0.0.1";
+					$content = "order deny,allow\ndeny from all\nallow from 127.0.0.1";
 					file_put_contents($file, $content);
 				}
 			}

--- a/lib/cache/.htaccess
+++ b/lib/cache/.htaccess
@@ -1,3 +1,3 @@
-order deny, allow
+order deny,allow
 deny from all
 allow from 127.0.0.1

--- a/lib/datastorage/.htaccess
+++ b/lib/datastorage/.htaccess
@@ -1,3 +1,3 @@
-order deny, allow
+order deny,allow
 deny from all
 allow from 127.0.0.1


### PR DESCRIPTION
According to [official documentation](http://httpd.apache.org/docs/current/mod/mod_access_compat.html#order) and real tests, keywords `allow` and `deny` may only
be separated by a comma; no _whitespace_ is allowed between them.

Now it will lead to 500 server error, and error msg in log, like
`[alert] [client 127.0.0.1] /var/www/bt/www/test-htaccess/.htaccess: order takes one argument, 'allow,deny', 'deny,allow', or 'mutual-failure'`

CC: @PhileCMS#183
